### PR TITLE
reinforce fix: the bug with fixed random seed was corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ python reinforce.py \
   --gamma 0.95 \
   --lr 0.5 \
   --momentum 0.1 \
-  --nepoch 1 \
+  --nepoch 4 \
   --nesterov \
   --ref_text data/negotiate/train.txt \
   --rl_clip 1 \
-  --rl_lr 0.1 \
+  --rl_lr 0.2 \
   --score_threshold 6 \
   --sv_train_freq 4 \
   --temperature 0.5 \

--- a/src/reinforce.py
+++ b/src/reinforce.py
@@ -115,7 +115,7 @@ def main():
         help='learning rate')
     parser.add_argument('--clip', type=float, default=0.1,
         help='gradient clip')
-    parser.add_argument('--rl_lr', type=float, default=0.1,
+    parser.add_argument('--rl_lr', type=float, default=0.2,
         help='RL learning rate')
     parser.add_argument('--rl_clip', type=float, default=0.1,
         help='RL gradient clip')
@@ -125,7 +125,7 @@ def main():
         help='batch size')
     parser.add_argument('--sv_train_freq', type=int, default=-1,
         help='supervision train frequency')
-    parser.add_argument('--nepoch', type=int, default=1,
+    parser.add_argument('--nepoch', type=int, default=4,
         help='number of epochs')
     parser.add_argument('--visual', action='store_true', default=False,
         help='plot graphs')
@@ -134,7 +134,6 @@ def main():
     args = parser.parse_args()
 
     device_id = utils.use_cuda(args.cuda)
-    utils.set_seed(args.seed)
 
     alice_model = utils.load_model(args.alice_model_file)
     # we don't want to use Dropout during RL


### PR DESCRIPTION
Dear authors,

Thank you for the very good paper "Deal or No Deal? End-to-End Learning for Negotiation Dialogues", I read it, and it's very interesting. 

I've tried to reproduce results with original code and parameters (https://github.com/facebookresearch/end-to-end-negotiator) but reinforce result is not the same as in the paper. I have the average score  (5.95 vs. 5.58) comparing with (7.1 vs 4.2). Also, I tried to tune parameters a little bit, but it does not help. Do you have any assumptions about the reason for it? 

---

Dear authors,

I've found the source of the problem, it was a very low-level effect. The random seed has been fixed (in reinforce.py line 137), however, small patches to interpretation or libraries may affect. So if I do not fix random seed and change optimization parameters a little bit I have (7.33 vs. 4.33) comparing with (5.95 vs. 5.58) in the original code, that is very close to the paper result (7.1 vs 4.2). Only one epoch for reinforce.py looks like mistype, I made 4. 

**original code reinforce.py results:** 
4000: dialog_len=4.73 sent_len=6.50 agree=90.67% advantage=0.41 time=0.091s comb_rew=11.53 alice_rew=5.95 alice_sel=69.30% alice_unique=2586 bob_rew=5.58 bob_sel=30.70% bob_unique=2227

**reinforce.py results (4 epoch):** 
16000: dialog_len=4.97 sent_len=6.66 agree=90.40% advantage=1.39 time=0.103s comb_rew=11.54 alice_rew=6.39 alice_sel=72.89% alice_unique=7342 bob_rew=5.14 bob_sel=27.11% bob_unique=6521

**reinforce.py results (4 epoch, tuning of the learning rate, non-fixed random seed):** 
16000: dialog_len=6.30 sent_len=7.28 agree=91.00% advantage=3.29 time=0.134s comb_rew=11.66 alice_rew=7.33 alice_sel=81.16% alice_unique=4345 bob_rew=4.33 bob_sel=18.84% bob_unique=9112
  