### PR TITLE
Fix syntax error in avg_rank.py

### DIFF
--- a/src/avg_rank.py
+++ b/src/avg_rank.py
@@ -16,7 +16,10 @@ import itertools
 import re
 import pdb
 
-import numpy as np import torch import torch.nn as nn import torch.optim as optim
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
 from torch.autograd import Variable
 
 import data

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,6 +10,7 @@ Various helpers.
 import random
 import copy
 import pdb
+import sys
 
 import torch
 import numpy as np


### PR DESCRIPTION
The carriage returns are significant in this context...

flake8 testing of https://github.com/facebookresearch/end-to-end-negotiator on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./src/avg_rank.py:19:25: E999 SyntaxError: invalid syntax
import numpy as np import torch import torch.nn as nn import torch.optim as optim
                        ^
./src/utils.py:106:17: F821 undefined name 'sys'
                sys.exit()
                ^
1     E999 SyntaxError: invalid syntax
1     F821 undefined name 'sys'
2
```